### PR TITLE
Fix a `'('` comparison bug in `parse` `Namelist`s

### DIFF
--- a/src/InputParsers/Namelists.jl
+++ b/src/InputParsers/Namelists.jl
@@ -67,7 +67,7 @@ function Base.parse(T::Type{<:Namelist}, str::AbstractString)
             if isnothing(item[:index])  # Cases like `ntyp = 2`
                 result[k] = parse(fieldtype(T, k), v)
             else  # An entry with multiple values, e.g., `celldm(2) = 3.0`.
-                if item[:kind] == '('
+                if item[:kind] == "("  # Note: it cannot be `'('`. It will result in `false`!
                     i = parse(Int, item[:index])
                     v = parse(Float64, v)  # TODO: This is tricky.
                     result[k] = if haskey(result, k)


### PR DESCRIPTION
This PR fixes the bug of parsing

```
&CONTROL
    calculation = 'scf'
    verbosity = 'high'
    outdir = './tmp'
    prefix = 'di'
    pseudo_dir = '~/pseudo'
/
&SYSTEM
    ibrav=  2
    celldm(1) =6.1 
    nat=  2
    ntyp= 1
    ecutwfc =40.0 
/
&ELECTRONS
    conv_thr = 1.0e-13
/
&IONS
/
&CELL
/
ATOMIC_SPECIES
    C 12.0 C.pbe-n-kjpaw_psl.1.0.0.UPF
ATOMIC_POSITIONS { crystal }
    C -0.125 -0.125 -0.125
    C 0.125 0.125 0.125
K_POINTS { automatic }
    12 12 12 0 0 0
```
will results in an `Inf` `celldm[1]`:
![image](https://user-images.githubusercontent.com/25192197/66882802-c6737180-ef99-11e9-92ef-fd1369d5b7a5.png)
as mentioned by @searchengineorientprogramming 
