### PR TITLE
Deprecate `_iterationwise!`

### DIFF
--- a/src/PWscf/output.jl
+++ b/src/PWscf/output.jl
@@ -261,6 +261,27 @@ function Base.tryparse(::Type{Diagonalization}, str::AbstractString)
     end
 end
 
+struct UnconvergedEnergy <: PWOutputParameter
+    total_energy::Float64
+    harris_foulkes_estimate::Maybe{Float64}
+    estimated_scf_accuracy::Float64
+end
+
+function Base.parse(::Type{UnconvergedEnergy}, str::AbstractString)
+    obj = tryparse(UnconvergedEnergy, str)
+    isnothing(obj) ? throw(ParseError("no matched string found!")) : return obj
+end
+function Base.tryparse(::Type{UnconvergedEnergy}, str::AbstractString)
+    matched = match(UNCONVERGED_ELECTRONS_ENERGY, str)
+    if isnothing(matched)
+        return nothing
+    else
+        ɛ, hf, δ = map(_parser, matched.captures)
+        return UnconvergedEnergy(ɛ, hf, δ)
+    end
+end
+_parser(x) = isnothing(x) ? x : parse(Float64, x)
+
 function _parse_nonconverged_energy(str::AbstractString)
     ɛ, hf, δ = nothing, nothing, nothing  # Initialization
     m = match(UNCONVERGED_ELECTRONS_ENERGY, str)

--- a/src/PWscf/output.jl
+++ b/src/PWscf/output.jl
@@ -165,7 +165,18 @@ function parse_stress(str::AbstractString)
     return pressures, atomic_stresses, kbar_stresses
 end # function parse_stress
 
-eachiteration(str::AbstractString) = eachmatch(ITERATION_BLOCK, str)
+struct EachIteration
+    iterator::Base.RegexMatchIterator
+end
+
+Base.iterate(iter::EachIteration) = iterate(iter.iterator)
+Base.iterate(iter::EachIteration, state) = iterate(iter.iterator, state)
+
+Base.eltype(::Type{EachIteration}) = String
+
+Base.IteratorSize(::Type{EachIteration}) = Base.SizeUnknown()
+
+eachiteration(str::AbstractString) = EachIteration(eachmatch(ITERATION_BLOCK, str))
 
 function _iterationwise!(f::Function, df::AbstractDataFrame, str::AbstractString)
     # Loop relax steps

--- a/src/PWscf/output.jl
+++ b/src/PWscf/output.jl
@@ -22,7 +22,6 @@ export Diagonalization,
     ProjectedPreconditionedConjugateGradient,
     parse_symmetries,
     parse_stress,
-    parse_iteration_time,
     parse_bands,
     parse_all_electron_energy,
     parse_energy_decomposition,
@@ -199,14 +198,22 @@ function Base.tryparse(::Type{IterationHead}, str::AbstractString)
     end
 end
 
-function parse_iteration_time(str::AbstractString)
-    df = DataFrame(; step=Int[], iteration=Int[], time=Float64[])
-    return _iterationwise!(_parse_iteration_time, df, str)
-end # function parse_iteration_time
-# This is a helper function and should not be exported.
-function _parse_iteration_time(str::AbstractString)
-    return parse(Float64, match(TOTAL_CPU_TIME, str)[1])
-end # function _parse_iteration_time
+struct IterationTime <: PWOutputParameter
+    time::Float64
+end
+
+function Base.parse(::Type{IterationTime}, str::AbstractString)
+    obj = tryparse(IterationTime, str)
+    isnothing(obj) ? throw(ParseError("no matched string found!")) : return obj
+end
+function Base.tryparse(::Type{IterationTime}, str::AbstractString)
+    matched = match(TOTAL_CPU_TIME, str)
+    if isnothing(matched)
+        return nothing
+    else
+        return IterationTime(parse(Float64, matched[1]))
+    end
+end
 
 function parse_diagonalization(str::AbstractString)
     df = DataFrame(;

--- a/src/PWscf/output.jl
+++ b/src/PWscf/output.jl
@@ -296,7 +296,28 @@ function Base.tryparse(::Type{UnconvergedEnergy}, str::AbstractString)
         return UnconvergedEnergy(ɛ, hf, δ)
     end
 end
+
 _parser(x) = isnothing(x) ? x : parse(Float64, x)
+
+struct ConvergedEnergy <: PWOutputParameter
+    total_energy::Float64
+    harris_foulkes_estimate::Maybe{Float64}
+    estimated_scf_accuracy::Float64
+end
+
+function Base.parse(::Type{ConvergedEnergy}, str::AbstractString)
+    obj = tryparse(ConvergedEnergy, str)
+    isnothing(obj) ? throw(ParseError("no matched string found!")) : return obj
+end
+function Base.tryparse(::Type{ConvergedEnergy}, str::AbstractString)
+    matched = match(CONVERGED_ELECTRONS_ENERGY, str)
+    if isnothing(matched)
+        return nothing
+    else
+        ɛ, hf, δ = map(_parser, matched.captures[1:3])
+        return ConvergedEnergy(ɛ, hf, δ)
+    end
+end
 
 function _parse_nonconverged_energy(str::AbstractString)
     ɛ, hf, δ = nothing, nothing, nothing  # Initialization

--- a/src/PWscf/output.jl
+++ b/src/PWscf/output.jl
@@ -34,6 +34,7 @@ export Diagonalization,
     parse_input_name,
     isoptimized,
     isjobdone,
+    eachstep,
     eachiteration,
     tryparsefirst,
     parsefirst,
@@ -164,6 +165,35 @@ function parse_stress(str::AbstractString)
     end
     return pressures, atomic_stresses, kbar_stresses
 end # function parse_stress
+
+struct EachStep
+    iterator::Base.RegexMatchIterator
+end
+
+function Base.iterate(iter::EachStep)
+    iterated = iterate(iter.iterator)
+    if isnothing(iterated)
+        return nothing
+    else
+        matched, state = iterated
+        return matched.match, state
+    end
+end
+function Base.iterate(iter::EachStep, state)
+    iterated = iterate(iter.iterator, state)
+    if isnothing(iterated)
+        return nothing
+    else
+        matched, state = iterated
+        return matched.match, state
+    end
+end
+
+Base.eltype(::Type{EachStep}) = String
+
+Base.IteratorSize(::Type{EachStep}) = Base.SizeUnknown()
+
+eachstep(str::AbstractString) = EachStep(eachmatch(SELF_CONSISTENT_CALCULATION_BLOCK, str))
 
 struct EachIteration
     iterator::Base.RegexMatchIterator

--- a/src/PWscf/output.jl
+++ b/src/PWscf/output.jl
@@ -169,8 +169,24 @@ struct EachIteration
     iterator::Base.RegexMatchIterator
 end
 
-Base.iterate(iter::EachIteration) = iterate(iter.iterator)
-Base.iterate(iter::EachIteration, state) = iterate(iter.iterator, state)
+function Base.iterate(iter::EachIteration)
+    iterated = iterate(iter.iterator)
+    if isnothing(iterated)
+        return nothing
+    else
+        matched, state = iterated
+        return matched.match, state
+    end
+end
+function Base.iterate(iter::EachIteration, state)
+    iterated = iterate(iter.iterator, state)
+    if isnothing(iterated)
+        return nothing
+    else
+        matched, state = iterated
+        return matched.match, state
+    end
+end
 
 Base.eltype(::Type{EachIteration}) = String
 

--- a/src/PWscf/output.jl
+++ b/src/PWscf/output.jl
@@ -34,6 +34,7 @@ export Diagonalization,
     parse_input_name,
     isoptimized,
     isjobdone,
+    eachiteration,
     tryparsefirst,
     parsefirst,
     tryparseall,
@@ -163,6 +164,8 @@ function parse_stress(str::AbstractString)
     end
     return pressures, atomic_stresses, kbar_stresses
 end # function parse_stress
+
+eachiteration(str::AbstractString) = eachmatch(ITERATION_BLOCK, str)
 
 function _iterationwise!(f::Function, df::AbstractDataFrame, str::AbstractString)
     # Loop relax steps

--- a/src/PWscf/output.jl
+++ b/src/PWscf/output.jl
@@ -223,17 +223,6 @@ Base.IteratorSize(::Type{EachIteration}) = Base.SizeUnknown()
 
 eachiteration(str::AbstractString) = EachIteration(eachmatch(ITERATION_BLOCK, str))
 
-function _iterationwise!(f::Function, df::AbstractDataFrame, str::AbstractString)
-    # Loop relax steps
-    for (i, scf) in enumerate(eachmatch(SELF_CONSISTENT_CALCULATION_BLOCK, str))
-        # Loop scf iterations
-        for (j, iter) in enumerate(eachmatch(ITERATION_BLOCK, scf[1]))
-            push!(df, [i j f(iter[1])...])
-        end
-    end
-    return df
-end # function _iterationwise
-
 struct IterationHead <: PWOutputParameter
     number::Int64
     ecut::Float64

--- a/src/PWscf/output.jl
+++ b/src/PWscf/output.jl
@@ -190,8 +190,9 @@ function _iterationwise!(f::Function, df::AbstractDataFrame, str::AbstractString
 end # function _iterationwise
 
 struct IterationHead <: PWOutputParameter
-    ecutwfc::Float64
-    mixing_beta::Float64
+    number::Int64
+    ecut::Float64
+    beta::Float64
 end
 
 function Base.parse(::Type{IterationHead}, str::AbstractString)
@@ -203,7 +204,9 @@ function Base.tryparse(::Type{IterationHead}, str::AbstractString)
     if isnothing(matched)
         return nothing
     else
-        return IterationHead(parse(Float64, matched[3]), parse(Float64, matched[4]))
+        return IterationHead(
+            parse(Int64, matched[1]), parse(Float64, matched[2]), parse(Float64, matched[3])
+        )
     end
 end
 

--- a/src/PWscf/regexes.jl
+++ b/src/PWscf/regexes.jl
@@ -1,4 +1,4 @@
-using ReadableRegex: capture, either, maybe, @rs_str
+using ReadableRegex: ANY, lazy_zero_or_more, capture, either, maybe, @rs_str
 
 # See https://gist.github.com/singularitti/e9e04c501ddfe40ba58917a754707b2e
 const INTEGER = raw"([-+]?[0-9]+)"
@@ -139,7 +139,10 @@ total\s+stress\s*\(Ry\/bohr\*\*3\)\s+
 ){3}
 )
 """mx
-const SELF_CONSISTENT_CALCULATION_BLOCK = r"(Self-consistent Calculation\X+?End of self-consistent calculation)"
+const SELF_CONSISTENT_CALCULATION_BLOCK =
+    rs"Self-consistent Calculation" *
+    capture(lazy_zero_or_more(ANY)) *
+    rs"End of self-consistent calculation"
 const ITERATION_BLOCK = r"(?<=iteration #)(.*?)(?=iteration #|End of self-consistent calculation)"s
 # This format is from https://github.com/QEF/q-e/blob/4132a64/PW/src/electrons.f90#L920-L921.
 # '     iteration #',I3,'     ecut=', F9.2,' Ry',5X,'beta=',F5.2


### PR DESCRIPTION
- Add type `EachStep` based on `Base.RegexMatchIterator` with iteration interface
- Add type `EachIteration` based on `Base.RegexMatchIterator` with iteration interface