### PR TITLE
Deprecate `parsefinal` & `REGEXOF`

### DIFF
--- a/src/PWscf/output/atomicstructure.jl
+++ b/src/PWscf/output/atomicstructure.jl
@@ -32,11 +32,6 @@ end # function tryparse_internal
 
 const AtomicStructure = Union{CellParametersCard,AtomicPositionsCard}
 
-function _parse(::Type{T}, str::AbstractString) where {T<:AtomicStructure}
-    x = tryparse(T, str)
-    return x === nothing ? throw(Meta.ParseError("cannot find `$(T)`!")) : x
-end # function _parse
-
 const REGEXOF = (
     CellParametersCard=CELL_PARAMETERS_BLOCK_OUTPUT,
     AtomicPositionsCard=ATOMIC_POSITIONS_BLOCK_OUTPUT,

--- a/src/PWscf/output/atomicstructure.jl
+++ b/src/PWscf/output/atomicstructure.jl
@@ -121,25 +121,3 @@ eachcellparameterscard(str::AbstractString) =
 
 eachatomicpositionscard(str::AbstractString) =
     EachParsed{AtomicPositionsCard}(ATOMIC_POSITIONS_BLOCK_OUTPUT, str)
-
-const AtomicStructure = Union{CellParametersCard,AtomicPositionsCard}
-
-const REGEXOF = (
-    CellParametersCard=CELL_PARAMETERS_BLOCK_OUTPUT,
-    AtomicPositionsCard=ATOMIC_POSITIONS_BLOCK_OUTPUT,
-)
-
-function _tryparsefinal(::Type{T}, str::AbstractString) where {T<:AtomicStructure}
-    m = match(FINAL_COORDINATES_BLOCK, str)
-    m === nothing && return nothing
-    m = match(REGEXOF[nameof(T)], m.match)
-    m === nothing && return nothing
-    return _tryparse(T, m.match)
-end # function parsefinal
-function parsefinal(::Type{T}, str::AbstractString) where {T<:AtomicStructure}
-    m = match(FINAL_COORDINATES_BLOCK, str)
-    m === nothing && throw(Meta.ParseError("No final coordinates found!"))
-    m = match(REGEXOF[nameof(T)], m.match)
-    m === nothing && throw(Meta.ParseError("No `CELL_PARAMETERS` found!"))
-    return _tryparse(T, m.match)
-end # function parsefinal

--- a/src/PWscf/output/atomicstructure.jl
+++ b/src/PWscf/output/atomicstructure.jl
@@ -51,6 +51,14 @@ Begin final coordinates
 End final coordinates
 """
 
+function Base.parse(::Type{CellParametersCard}, str::AbstractString)
+    obj = tryparse(CellParametersCard, str)
+    isnothing(obj) ? throw(ParseError("no matched string found!")) : return obj
+end
+function Base.parse(::Type{AtomicPositionsCard}, str::AbstractString)
+    obj = tryparse(AtomicPositionsCard, str)
+    isnothing(obj) ? throw(ParseError("no matched string found!")) : return obj
+end
 function Base.tryparse(::Type{CellParametersCard}, str::AbstractString)
     matched = match(CELL_PARAMETERS_BLOCK_OUTPUT, str)
     if isnothing(matched)

--- a/src/PWscf/output/atomicstructure.jl
+++ b/src/PWscf/output/atomicstructure.jl
@@ -95,6 +95,27 @@ function _tryparse(::Type{AtomicPositionsCard}, str::AbstractString)
     end
 end
 
+function Base.iterate(regexmatchiterator::EachParsed{CellParametersCard})
+    regexmatchiterator = eachmatch(regexmatchiterator.regex, regexmatchiterator.string)
+    iterated = iterate(regexmatchiterator)
+    if isnothing(iterated)
+        return nothing
+    else
+        matched, state = iterated
+        return _tryparse(CellParametersCard, matched.match), state
+    end
+end
+function Base.iterate(regexmatchiterator::EachParsed{CellParametersCard}, state)
+    regexmatchiterator = eachmatch(regexmatchiterator.regex, regexmatchiterator.string)
+    iterated = iterate(regexmatchiterator, state)
+    if isnothing(iterated)
+        return nothing
+    else
+        matched, state = iterated
+        return _tryparse(CellParametersCard, matched.match), state
+    end
+end
+
 eachcellparameterscard(str::AbstractString) =
     EachParsed{CellParametersCard}(CELL_PARAMETERS_BLOCK_OUTPUT, str)
 

--- a/src/PWscf/output/atomicstructure.jl
+++ b/src/PWscf/output/atomicstructure.jl
@@ -45,11 +45,6 @@ const ATOMIC_POSITIONS_ITEM_OUTPUT = r"""
 ([-+]?[0-9]+)? \s*            # if_pos(2)
 ([-+]?[0-9]+)? \s*            # if_pos(3)
 """x
-const FINAL_COORDINATES_BLOCK = r"""
-Begin final coordinates
-(\X+?)
-End final coordinates
-"""
 
 function Base.parse(::Type{CellParametersCard}, str::AbstractString)
     obj = _tryparse(CellParametersCard, str)

--- a/src/PWscf/output/atomicstructure.jl
+++ b/src/PWscf/output/atomicstructure.jl
@@ -52,14 +52,14 @@ End final coordinates
 """
 
 function Base.parse(::Type{CellParametersCard}, str::AbstractString)
-    obj = tryparse(CellParametersCard, str)
+    obj = _tryparse(CellParametersCard, str)
     isnothing(obj) ? throw(ParseError("no matched string found!")) : return obj
 end
 function Base.parse(::Type{AtomicPositionsCard}, str::AbstractString)
-    obj = tryparse(AtomicPositionsCard, str)
+    obj = _tryparse(AtomicPositionsCard, str)
     isnothing(obj) ? throw(ParseError("no matched string found!")) : return obj
 end
-function Base.tryparse(::Type{CellParametersCard}, str::AbstractString)
+function _tryparse(::Type{CellParametersCard}, str::AbstractString)
     matched = match(CELL_PARAMETERS_BLOCK_OUTPUT, str)
     if isnothing(matched)
         return nothing
@@ -77,7 +77,7 @@ function Base.tryparse(::Type{CellParametersCard}, str::AbstractString)
         end
     end
 end
-function Base.tryparse(::Type{AtomicPositionsCard}, str::AbstractString)
+function _tryparse(::Type{AtomicPositionsCard}, str::AbstractString)
     matched = match(ATOMIC_POSITIONS_BLOCK_OUTPUT, str)
     if isnothing(matched)
         return nothing
@@ -108,17 +108,17 @@ const REGEXOF = (
     AtomicPositionsCard=ATOMIC_POSITIONS_BLOCK_OUTPUT,
 )
 
-function tryparsefinal(::Type{T}, str::AbstractString) where {T<:AtomicStructure}
+function _tryparsefinal(::Type{T}, str::AbstractString) where {T<:AtomicStructure}
     m = match(FINAL_COORDINATES_BLOCK, str)
     m === nothing && return nothing
     m = match(REGEXOF[nameof(T)], m.match)
     m === nothing && return nothing
-    return tryparse(T, m.match)
+    return _tryparse(T, m.match)
 end # function parsefinal
 function parsefinal(::Type{T}, str::AbstractString) where {T<:AtomicStructure}
     m = match(FINAL_COORDINATES_BLOCK, str)
     m === nothing && throw(Meta.ParseError("No final coordinates found!"))
     m = match(REGEXOF[nameof(T)], m.match)
     m === nothing && throw(Meta.ParseError("No `CELL_PARAMETERS` found!"))
-    return tryparse(T, m.match)
+    return _tryparse(T, m.match)
 end # function parsefinal

--- a/src/PWscf/output/atomicstructure.jl
+++ b/src/PWscf/output/atomicstructure.jl
@@ -42,47 +42,6 @@ const REGEXOF = (
     AtomicPositionsCard=ATOMIC_POSITIONS_BLOCK_OUTPUT,
 )
 
-tryparsefirst(::Type{T}, str::AbstractString) where {T<:AtomicStructure} =
-    tryparse_internal(T, str)
-parsefirst(::Type{T}, str::AbstractString) where {T<:AtomicStructure} = _parse(T, str)
-
-function tryparseall(::Type{T}, str::AbstractString) where {T<:AtomicStructure}
-    return map(eachmatch(REGEXOF[nameof(T)], str)) do x
-        try
-            tryparse_internal(T, x.match)
-        catch
-            nothing
-        end
-    end
-end # function parseall
-function parseall(::Type{T}, str::AbstractString) where {T<:AtomicStructure}
-    return map(eachmatch(REGEXOF[nameof(T)], str)) do x
-        try
-            tryparse_internal(T, x.match)
-        catch
-            Meta.ParseError("Pass failed!")
-        end
-    end
-end # function parseall
-
-tryparselast(::Type{T}, str::AbstractString) where {T<:AtomicStructure} =
-    tryparseall(T, str)[end]
-parselast(::Type{T}, str::AbstractString) where {T<:AtomicStructure} = parseall(T, str)[end]
-
-function _parsenext_internal(
-    ::Type{T}, str::AbstractString, start::Integer, raise::Bool
-) where {T}
-    x = findnext(REGEXOF[nameof(T)], str, start)
-    if x === nothing
-        raise ? throw(Meta.ParseError("Nothing found for next!")) : return nothing
-    end
-    return tryparse_internal(T, str[x])
-end # function parsenext
-tryparsenext(::Type{T}, str::AbstractString, start::Integer) where {T} =
-    _parsenext_internal(T, str, start, false)
-parsenext(::Type{T}, str::AbstractString, start::Integer) where {T} =
-    _parsenext_internal(T, str, start, true)
-
 function tryparsefinal(::Type{T}, str::AbstractString) where {T<:AtomicStructure}
     m = match(FINAL_COORDINATES_BLOCK, str)
     m === nothing && return nothing

--- a/src/PWscf/output/atomicstructure.jl
+++ b/src/PWscf/output/atomicstructure.jl
@@ -1,3 +1,5 @@
+export eachcellparameterscard, eachatomicpositionscard
+
 # The following format is from https://github.com/QEF/q-e/blob/4132a64/PW/src/output_tau.f90#L47-L60.
 const CELL_PARAMETERS_BLOCK_OUTPUT = r"""
 CELL_PARAMETERS \h+
@@ -80,6 +82,12 @@ function tryparse_internal(::Type{AtomicPositionsCard}, str::AbstractString)
         AtomicPositionsCard(data, option)
     end
 end # function tryparse_internal
+
+eachcellparameterscard(str::AbstractString) =
+    EachParsed{CellParametersCard}(CELL_PARAMETERS_BLOCK_OUTPUT, str)
+
+eachatomicpositionscard(str::AbstractString) =
+    EachParsed{AtomicPositionsCard}(ATOMIC_POSITIONS_BLOCK_OUTPUT, str)
 
 const AtomicStructure = Union{CellParametersCard,AtomicPositionsCard}
 

--- a/src/PWscf/output/atomicstructure.jl
+++ b/src/PWscf/output/atomicstructure.jl
@@ -1,3 +1,54 @@
+# The following format is from https://github.com/QEF/q-e/blob/4132a64/PW/src/output_tau.f90#L47-L60.
+const CELL_PARAMETERS_BLOCK_OUTPUT = r"""
+CELL_PARAMETERS \h+
+\( (?<option>\w+) =? \s* (?<alat>[-+]?[0-9]*\.[0-9]{8})? \) \h*  # Match `alat`: `F12.8`
+(?<data>
+    (?: \s*
+        (?:
+            [-+]?[0-9]*\.[0-9]+ \s*  # Match element
+        ){3}  # I need exactly 3 elements per vector
+    ){3}  # I need exactly 3 vectors
+)
+"""x
+const CELL_PARAMETERS_ITEM_OUTPUT = r"""
+\s*
+([-+]?[0-9]*\.[0-9]+) \s*  # x
+([-+]?[0-9]*\.[0-9]+) \s*  # y
+([-+]?[0-9]*\.[0-9]+) \s*  # z
+"""x
+# The following format is from https://github.com/QEF/q-e/blob/4132a64/PW/src/output_tau.f90#L64-L109.
+const ATOMIC_POSITIONS_BLOCK_OUTPUT = r"""
+ATOMIC_POSITIONS \h*                   # Atomic positions start with that string
+\( (?<option>\w+) \)                   # Option of the card
+(?<data>
+    (?:
+        \s*
+        [A-Za-z]+[A-Za-z0-9]{0,2} \s+  # Atom spec
+        (?:
+            [-+]?[0-9]*\.[0-9]+ \s*  # Match element
+        ){3}                           # I need exactly 3 floats per vector.
+        (?:
+            [-+]?[0-9]+ \s*
+        ){0,3}                     # I need exactly 3 integers in `if_pos`, if there is any.
+    )+
+)
+"""x
+const ATOMIC_POSITIONS_ITEM_OUTPUT = r"""
+\s*
+([A-Za-z]+[A-Za-z0-9]{0,2}) \s+  # Atom spec
+([-+]?[0-9]*\.[0-9]+) \s*  # x
+([-+]?[0-9]*\.[0-9]+) \s*  # y
+([-+]?[0-9]*\.[0-9]+) \s*  # z
+([-+]?[0-9]+)? \s*            # if_pos(1)
+([-+]?[0-9]+)? \s*            # if_pos(2)
+([-+]?[0-9]+)? \s*            # if_pos(3)
+"""x
+const FINAL_COORDINATES_BLOCK = r"""
+Begin final coordinates
+(\X+?)
+End final coordinates
+"""
+
 function tryparse_internal(::Type{CellParametersCard}, str::AbstractString)
     m = match(CELL_PARAMETERS_BLOCK_OUTPUT, str)
     return if m !== nothing

--- a/src/PWscf/output/regexes.jl
+++ b/src/PWscf/output/regexes.jl
@@ -73,56 +73,6 @@ number of k points=\s*(?<nk>[0-9]+)\h*(?<metainfo>.*)
 const K_POINTS_ITEM = Regex(
     "k\\(.*\\) = \\(\\s*$FIXED_POINT_REAL\\s*$FIXED_POINT_REAL\\s*$FIXED_POINT_REAL\\s*\\), wk =\\s*$FIXED_POINT_REAL",
 )
-# The following format is from https://github.com/QEF/q-e/blob/4132a64/PW/src/output_tau.f90#L47-L60.
-const CELL_PARAMETERS_BLOCK_OUTPUT = r"""
-CELL_PARAMETERS \h+
-\( (?<option>\w+) =? \s* (?<alat>[-+]?[0-9]*\.[0-9]{8})? \) \h*  # Match `alat`: `F12.8`
-(?<data>
-    (?: \s*
-        (?:
-            [-+]?[0-9]*\.[0-9]+ \s*  # Match element
-        ){3}  # I need exactly 3 elements per vector
-    ){3}  # I need exactly 3 vectors
-)
-"""x
-const CELL_PARAMETERS_ITEM_OUTPUT = r"""
-\s*
-([-+]?[0-9]*\.[0-9]+) \s*  # x
-([-+]?[0-9]*\.[0-9]+) \s*  # y
-([-+]?[0-9]*\.[0-9]+) \s*  # z
-"""x
-# The following format is from https://github.com/QEF/q-e/blob/4132a64/PW/src/output_tau.f90#L64-L109.
-const ATOMIC_POSITIONS_BLOCK_OUTPUT = r"""
-ATOMIC_POSITIONS \h*                   # Atomic positions start with that string
-\( (?<option>\w+) \)                   # Option of the card
-(?<data>
-    (?:
-        \s*
-        [A-Za-z]+[A-Za-z0-9]{0,2} \s+  # Atom spec
-        (?:
-            [-+]?[0-9]*\.[0-9]+ \s*  # Match element
-        ){3}                           # I need exactly 3 floats per vector.
-        (?:
-            [-+]?[0-9]+ \s*
-        ){0,3}                     # I need exactly 3 integers in `if_pos`, if there is any.
-    )+
-)
-"""x
-const ATOMIC_POSITIONS_ITEM_OUTPUT = r"""
-\s*
-([A-Za-z]+[A-Za-z0-9]{0,2}) \s+  # Atom spec
-([-+]?[0-9]*\.[0-9]+) \s*  # x
-([-+]?[0-9]*\.[0-9]+) \s*  # y
-([-+]?[0-9]*\.[0-9]+) \s*  # z
-([-+]?[0-9]+)? \s*            # if_pos(1)
-([-+]?[0-9]+)? \s*            # if_pos(2)
-([-+]?[0-9]+)? \s*            # if_pos(3)
-"""x
-const FINAL_COORDINATES_BLOCK = r"""
-Begin final coordinates
-(\X+?)
-End final coordinates
-"""
 const STRESS_BLOCK = r"""
 ^[ \t]*
 total\s+stress\s*\(Ry\/bohr\*\*3\)\s+


### PR DESCRIPTION
Verified they are equal to the last of `EachParsed{CellParametersCard}` & `EachParsed{AtomicPositionsCard}`