### PR TITLE
Modify `each.jl` to use `parse` instead of `tryparse` in the `iterate` function for `EachParsed`

### DIFF
--- a/src/PWscf/output/each.jl
+++ b/src/PWscf/output/each.jl
@@ -87,7 +87,7 @@ function Base.iterate(regexmatchiterator::EachParsed{T}) where {T}
         return nothing
     else
         matched, state = iterated
-        return tryparse(T, matched.match), state
+        return parse(T, matched.match), state
     end
 end
 function Base.iterate(regexmatchiterator::EachParsed{T}, state) where {T}
@@ -97,7 +97,7 @@ function Base.iterate(regexmatchiterator::EachParsed{T}, state) where {T}
         return nothing
     else
         matched, state = iterated
-        return tryparse(T, matched.match), state
+        return parse(T, matched.match), state
     end
 end
 


### PR DESCRIPTION
There is no possibility when iterating it will return a `nothing` in the current implementation. And

```julia
Base.eltype(::Type{EachParsed{T}}) where {T} = T
```

does not let it to return a `Nothing`. Also, using `parse` is more aligned with the name `EachParsed`.